### PR TITLE
feat : add python code formatter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,8 @@
+# Run lint-staged for JavaScript/TypeScript/other staged files
+echo "🔍 Running lint-staged for staged files in Javascript/TypeScript..."
 npm run lint-staged
+
+# Run make lint for Python files (ensure pre-commit is set up)
+echo "🔍 Running make lint for Python files..."
+cd ludwig-nlu && make lint
+ 

--- a/ludwig-nlu/.flake8
+++ b/ludwig-nlu/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 120
+exclude = venv, .tox, *.egg, *_pb2.py, build, temp,
+select = E, W, F
+doctests = true
+ignore = E731, W503, E203, E231, E241, E221, E225, E226, E271, E275

--- a/ludwig-nlu/.pre-commit-config.yaml
+++ b/ludwig-nlu/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# Apply to all files without committing:
+#   pre-commit run --all-files
+# Apply to changed files:
+#   pre-commit run
+# Update this file:
+#   pre-commit autoupdate
+# Run a specific hook:
+#   pre-commit run <hook id>
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: weekly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-ast
+        files: \.py$  # Restrict to .py files only
+      - id: check-byte-order-marker
+        files: \.py$  # Restrict to .py files only
+      - id: check-case-conflict
+        files: \.py$  # Restrict to .py files only
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+        files: \.py$  # Restrict to .py files only
+      - id: detect-private-key
+      - id: end-of-file-fixer
+        files: \.py$  # Restrict to .py files only
+      - id: trailing-whitespace
+        files: \.py$  # Restrict to .py files only
+      - id: mixed-line-ending
+        files: \.py$  # Restrict to .py files only
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+        files: \.py$  # Restrict to .py files only
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+        files: \.py$  # Restrict to .py files only
+        name: Format imports
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+        files: \.py$  # Restrict to .py files only
+        args: ['--config', 'ludwig-nlu/.flake8'] 
+  # black for automatic code formatting
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: \.py$
+        language_version: python3
+        name: Format code
+  - repo: https://github.com/yoheimuta/protolint
+    rev: v0.53.0
+    hooks:
+      - id: protolint
+        files: \.proto$  # Leave protolint for .proto files only

--- a/ludwig-nlu/.protolint.yaml
+++ b/ludwig-nlu/.protolint.yaml
@@ -1,0 +1,51 @@
+
+# Adapted from
+# https://github.com/yoheimuta/protolint/blob/master/_example/config/.protolint.yaml
+---
+# Lint directives.
+lint:
+  # Linter files to walk.
+  files:
+    # The specific files to exclude.
+    exclude:
+      # NOTE: UNIX paths will be properly accepted by both UNIX and Windows.
+      - ../proto/invalidFileName.proto
+
+  # Linter rules.
+  # Run `protolint list` to see all available rules.
+  rules:
+  
+    # The specific linters to add.
+    add:
+      - FIELD_NAMES_LOWER_SNAKE_CASE
+      - MESSAGE_NAMES_UPPER_CAMEL_CASE
+      - MAX_LINE_LENGTH
+      - INDENT
+      - FIELD_NAMES_EXCLUDE_PREPOSITIONS
+      - FILE_NAMES_LOWER_SNAKE_CASE
+      - IMPORTS_SORTED
+      - PACKAGE_NAME_LOWER_CASE
+      - ORDER
+      - PROTO3_FIELDS_AVOID_REQUIRED
+      - PROTO3_GROUPS_AVOID
+      - REPEATED_FIELD_NAMES_PLURALIZED
+      - QUOTE_CONSISTENT
+
+  # Linter rules option.
+  rules_option:
+    # MAX_LINE_LENGTH rule option.
+    max_line_length:
+      # Enforces a maximum line length
+      max_chars: 120
+      # Specifies the character count for tab characters
+      tab_chars: 2
+
+    # FILE_NAMES_LOWER_SNAKE_CASE rule option.
+    file_names_lower_snake_case:
+      excludes:
+        - ../proto/invalidFileName.proto
+
+    # QUOTE_CONSISTENT rule option.
+    quote_consistent:
+      # Available quote are "double" or "single".
+      quote: double

--- a/ludwig-nlu/Makefile
+++ b/ludwig-nlu/Makefile
@@ -1,0 +1,22 @@
+
+# Run pre-commit hooks on all files
+lint:
+	@echo "Running pre-commit linting on all files..."
+	pre-commit run --all-files
+
+# Run pre-commit hooks on changed files
+lint-changed-files:
+	@echo "Running pre-commit lint on changed files..."
+	pre-commit run
+
+# Update pre-commit hooks to the latest versions
+autoupdate:
+	@echo "Updating pre-commit hooks..."
+	pre-commit autoupdate
+
+# Run a specific hook (e.g., flake8, black, isort, etc.)
+run-lint-hook:
+	@echo "Running specific hook: $(hook)"
+	pre-commit run $(hook)
+
+.PHONY: lint lint-changed-files autoupdate run-lint-hook

--- a/ludwig-nlu/multi_serve.py
+++ b/ludwig-nlu/multi_serve.py
@@ -40,9 +40,7 @@ except ImportError as e:
 
 ALL_FEATURES_PRESENT_ERROR = {"error": "entry must contain all input features"}
 
-COULD_NOT_RUN_INFERENCE_ERROR = {
-    "error": "Unexpected Error: could not run inference on model"
-}
+COULD_NOT_RUN_INFERENCE_ERROR = {"error": "Unexpected Error: could not run inference on model"}
 
 AUTH_TOKEN = os.getenv("AUTH_TOKEN", "TOKEN_MUST_BE_DEFINED")
 
@@ -68,18 +66,14 @@ def validate_and_get_project_name(repo_name: str) -> str:
     """
     # Check if the repo name contains exactly one '/'
     if repo_name.count("/") != 1:
-        raise ValueError(
-            "Invalid repository name format. It must be in 'Owner/ProjectName' format."
-        )
+        raise ValueError("Invalid repository name format. It must be in 'Owner/ProjectName' format.")
 
     # Split the repository name into owner and project name
     owner, project_name = repo_name.split("/")
 
     # Validate that both owner and project name are non-empty
     if not owner or not project_name:
-        raise ValueError(
-            "Invalid repository name. Both owner and project name must be non-empty."
-        )
+        raise ValueError("Invalid repository name. Both owner and project name must be non-empty.")
 
     # Return the project name if the validation is successful
     return project_name
@@ -96,9 +90,7 @@ def process_repo_name(repo_name: str, save_dir: Optional[str]) -> Tuple[str, str
     return repo_name, repo_dir, save_dir
 
 
-def download_model_from_huggingface(
-    repo_id: str, repo_dir: str, force_download: bool = True
-) -> None:
+def download_model_from_huggingface(repo_id: str, repo_dir: str, force_download: bool = True) -> None:
     """
     Download the model from Hugging Face if not already present in the local directory.
 
@@ -114,12 +106,7 @@ def download_model_from_huggingface(
 
         # Download the model from Hugging Face
         try:
-            snapshot_download(
-                repo_id=repo_id,
-                force_download=force_download,
-                local_dir=repo_dir,
-                repo_type="model",
-            )
+            snapshot_download(repo_id=repo_id, force_download=force_download, local_dir=repo_dir, repo_type="model")
         except Exception as e:
             logging.warning(f"Failed to download the model from hugging_face: {e}")
 
@@ -182,18 +169,12 @@ def load_model(
 
 
 def server(models, allowed_origins=None):
-    middleware = (
-        [Middleware(CORSMiddleware, allow_origins=allowed_origins)]
-        if allowed_origins
-        else None
-    )
+    middleware = [Middleware(CORSMiddleware, allow_origins=allowed_origins)] if allowed_origins else None
     app = FastAPI(middleware=middleware)
 
     @app.get("/")
     def check_health():
-        return NumpyJSONResponse(
-            {"message": "Ludwig server is up", "models": list(models.keys())}
-        )
+        return NumpyJSONResponse({"message": "Ludwig server is up", "models": list(models.keys())})
 
     @app.post("/predict")
     async def predict(request: Request):
@@ -209,9 +190,7 @@ def server(models, allowed_origins=None):
 
         async def predict_by_model(model_name: str, model: LudwigModel) -> dict:
             try:
-                entry, files = convert_input(
-                    form, model.model.input_features
-                )  # Input compatible with all models
+                entry, files = convert_input(form, model.model.input_features)  # Input compatible with all models
                 input_features = {f[COLUMN] for f in model.config["input_features"]}
                 if (entry.keys() & input_features) != input_features:
                     missing_features = set(input_features) - set(entry.keys())
@@ -246,9 +225,7 @@ def server(models, allowed_origins=None):
                 invalid_models = [name for name in model_names if name not in models]
                 if invalid_models:
                     return NumpyJSONResponse(
-                        {
-                            "error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."
-                        },
+                        {"error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."},
                         status_code=400,
                     )
                 target_models = {name: models[name] for name in model_names}
@@ -257,9 +234,7 @@ def server(models, allowed_origins=None):
                 target_models = models
 
             # Run
-            tasks = [
-                predict_by_model(name, model) for name, model in target_models.items()
-            ]
+            tasks = [predict_by_model(name, model) for name, model in target_models.items()]
             results = await asyncio.gather(*tasks)
             responses = {result["model"]: result["response"] for result in results}
             return NumpyJSONResponse(responses)
@@ -286,9 +261,7 @@ def server(models, allowed_origins=None):
         async def batch_predict_by_model(model_name: str, model: LudwigModel) -> dict:
             try:
                 data, files = convert_batch_input(form, model.model.input_features)
-                data_df = pd.DataFrame.from_records(
-                    data["data"], index=data.get("index"), columns=data["columns"]
-                )
+                data_df = pd.DataFrame.from_records(data["data"], index=data.get("index"), columns=data["columns"])
                 input_features = {f[COLUMN] for f in model.config["input_features"]}
 
                 if (set(data_df.columns) & input_features) != input_features:
@@ -309,9 +282,7 @@ def server(models, allowed_origins=None):
                     },
                 }
             except Exception as exc:
-                logger.exception(
-                    f"Failed to batch predict for model '{model_name}': {exc}"
-                )
+                logger.exception(f"Failed to batch predict for model '{model_name}': {exc}")
                 return {
                     "model": model_name,
                     "response": {
@@ -326,9 +297,7 @@ def server(models, allowed_origins=None):
                 invalid_models = [name for name in model_names if name not in models]
                 if invalid_models:
                     return NumpyJSONResponse(
-                        {
-                            "error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."
-                        },
+                        {"error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."},
                         status_code=400,
                     )
                 target_models = {name: models[name] for name in model_names}
@@ -336,10 +305,7 @@ def server(models, allowed_origins=None):
                 target_models = models
 
             # Run batch predictions
-            tasks = [
-                batch_predict_by_model(name, model)
-                for name, model in target_models.items()
-            ]
+            tasks = [batch_predict_by_model(name, model) for name, model in target_models.items()]
             results = await asyncio.gather(*tasks)
             responses = {result["model"]: result["response"] for result in results}
             return NumpyJSONResponse(responses)
@@ -430,9 +396,7 @@ def run_server(
     for model_name, repo_id in model_paths.items():
         if mode == "huggingface":
             repo_id, repo_dir, save_dir = process_repo_name(repo_id, "model")
-            models[model_name] = load_model(
-                save_dir, repo_dir, repo_id=repo_id, backend="local"
-            )
+            models[model_name] = load_model(save_dir, repo_dir, repo_id=repo_id, backend="local")
         elif mode == "local":
             models[model_name] = LudwigModel.load(repo_id, backend="local")
 
@@ -488,9 +452,7 @@ def cli(sys_argv):
         type=int,
     )
 
-    parser.add_argument(
-        "-H", "--host", help="host for server (default: 0.0.0.0)", default="0.0.0.0"
-    )
+    parser.add_argument("-H", "--host", help="host for server (default: 0.0.0.0)", default="0.0.0.0")
 
     parser.add_argument(
         "-ao",

--- a/ludwig-nlu/multi_serve.py
+++ b/ludwig-nlu/multi_serve.py
@@ -6,22 +6,19 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Dict, Optional, Tuple, Union, List
+from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import torch
-from torchvision.io import decode_image
-
+from huggingface_hub import login, snapshot_download
 from ludwig.api import LudwigModel
 from ludwig.constants import AUDIO, COLUMN
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import get_logging_level_registry, print_ludwig
 from ludwig.utils.server_utils import NumpyJSONResponse
-from ludwig.backend import Backend
-from ludwig.callbacks import Callback
+from torchvision.io import decode_image
 
-from huggingface_hub import snapshot_download, login
 logger = logging.getLogger(__name__)
 
 try:
@@ -43,7 +40,9 @@ except ImportError as e:
 
 ALL_FEATURES_PRESENT_ERROR = {"error": "entry must contain all input features"}
 
-COULD_NOT_RUN_INFERENCE_ERROR = {"error": "Unexpected Error: could not run inference on model"}
+COULD_NOT_RUN_INFERENCE_ERROR = {
+    "error": "Unexpected Error: could not run inference on model"
+}
 
 AUTH_TOKEN = os.getenv("AUTH_TOKEN", "TOKEN_MUST_BE_DEFINED")
 
@@ -53,52 +52,56 @@ HF_AUTH_TOKEN = os.getenv("HF_AUTH_TOKEN")
 if HF_AUTH_TOKEN:
     login(token=HF_AUTH_TOKEN)
 
-def validate_and_get_project_name(repo_name:str) -> str:
+
+def validate_and_get_project_name(repo_name: str) -> str:
     """
     Validate a HuggingFace repository name and return the project name.
-    
+
     Parameters:
         repo_name (str): The repository name in the format 'Owner/ProjectName'.
-        
+
     Returns:
         str: The project name if the repo_name is valid.
-        
+
     Raises:
         ValueError: If the repo_name is not in the correct format.
     """
     # Check if the repo name contains exactly one '/'
-    if repo_name.count('/') != 1:
-        raise ValueError("Invalid repository name format. It must be in 'Owner/ProjectName' format.")
-    
+    if repo_name.count("/") != 1:
+        raise ValueError(
+            "Invalid repository name format. It must be in 'Owner/ProjectName' format."
+        )
+
     # Split the repository name into owner and project name
-    owner, project_name = repo_name.split('/')
-    
+    owner, project_name = repo_name.split("/")
+
     # Validate that both owner and project name are non-empty
     if not owner or not project_name:
-        raise ValueError("Invalid repository name. Both owner and project name must be non-empty.")
-    
+        raise ValueError(
+            "Invalid repository name. Both owner and project name must be non-empty."
+        )
+
     # Return the project name if the validation is successful
     return project_name
 
+
 def process_repo_name(repo_name: str, save_dir: Optional[str]) -> Tuple[str, str, str]:
     if repo_name is not None:
-            project_name = validate_and_get_project_name(repo_name)
-            repo_dir = os.path.join("repos", project_name)
-            if save_dir is not None:
-                save_dir = os.path.join("repos", project_name, save_dir)
-            else:
-                save_dir = os.path.join("repos", project_name)
+        project_name = validate_and_get_project_name(repo_name)
+        repo_dir = os.path.join("repos", project_name)
+        if save_dir is not None:
+            save_dir = os.path.join("repos", project_name, save_dir)
+        else:
+            save_dir = os.path.join("repos", project_name)
     return repo_name, repo_dir, save_dir
-     
+
 
 def download_model_from_huggingface(
-    repo_id: str,
-    repo_dir: str,
-    force_download: bool = True
+    repo_id: str, repo_dir: str, force_download: bool = True
 ) -> None:
     """
     Download the model from Hugging Face if not already present in the local directory.
-    
+
     Args:
     - repo_id: Hugging Face repository ID of the model.
     - repo_dir: Local directory to store the downloaded model.
@@ -108,14 +111,14 @@ def download_model_from_huggingface(
     if not os.path.isdir(repo_dir) or force_download:
         # Create the repository directory if it doesn't exist
         os.makedirs(repo_dir, exist_ok=True)
-        
+
         # Download the model from Hugging Face
         try:
             snapshot_download(
                 repo_id=repo_id,
                 force_download=force_download,
                 local_dir=repo_dir,
-                repo_type="model"
+                repo_type="model",
             )
         except Exception as e:
             logging.warning(f"Failed to download the model from hugging_face: {e}")
@@ -135,7 +138,7 @@ def load_model(
 ) -> Optional[LudwigModel]:
     """
     Load a pretrained model from the specified directory, or download it from Hugging Face if necessary.
-    
+
     This function first checks if the model is available locally, and if not,
     it downloads it from the Hugging Face Hub. It then loads the model using Ludwig's
     `LudwigModel.load()` method, which handles restoring the model's weights, config,
@@ -170,22 +173,28 @@ def load_model(
             gpu_memory_limit=gpu_memory_limit,
             allow_parallel_threads=allow_parallel_threads,
             callbacks=callbacks,
-            from_checkpoint=from_checkpoint
+            from_checkpoint=from_checkpoint,
         )
         return ludwig_model
     except Exception as e:
         logging.warning(f"Failed to load the model: {e}")
         return None
 
+
 def server(models, allowed_origins=None):
-    middleware = [Middleware(CORSMiddleware, allow_origins=allowed_origins)] if allowed_origins else None
+    middleware = (
+        [Middleware(CORSMiddleware, allow_origins=allowed_origins)]
+        if allowed_origins
+        else None
+    )
     app = FastAPI(middleware=middleware)
 
     @app.get("/")
     def check_health():
-        return NumpyJSONResponse({"message": "Ludwig server is up", "models": list(models.keys())})
-        
-    
+        return NumpyJSONResponse(
+            {"message": "Ludwig server is up", "models": list(models.keys())}
+        )
+
     @app.post("/predict")
     async def predict(request: Request):
         try:
@@ -200,7 +209,9 @@ def server(models, allowed_origins=None):
 
         async def predict_by_model(model_name: str, model: LudwigModel) -> dict:
             try:
-                entry, files = convert_input(form, model.model.input_features)  # Input compatible with all models
+                entry, files = convert_input(
+                    form, model.model.input_features
+                )  # Input compatible with all models
                 input_features = {f[COLUMN] for f in model.config["input_features"]}
                 if (entry.keys() & input_features) != input_features:
                     missing_features = set(input_features) - set(entry.keys())
@@ -235,16 +246,20 @@ def server(models, allowed_origins=None):
                 invalid_models = [name for name in model_names if name not in models]
                 if invalid_models:
                     return NumpyJSONResponse(
-                        {"error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."},
+                        {
+                            "error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."
+                        },
                         status_code=400,
                     )
                 target_models = {name: models[name] for name in model_names}
-            else:  
+            else:
                 # Predict for all models if no specific model(s) are provided
                 target_models = models
 
-            # Run 
-            tasks = [predict_by_model(name, model) for name, model in target_models.items()]
+            # Run
+            tasks = [
+                predict_by_model(name, model) for name, model in target_models.items()
+            ]
             results = await asyncio.gather(*tasks)
             responses = {result["model"]: result["response"] for result in results}
             return NumpyJSONResponse(responses)
@@ -262,16 +277,18 @@ def server(models, allowed_origins=None):
             form = await request.form()
             model_names = form.get("model")  # Single model or list of models
             model_names = model_names.split(",") if model_names else None
-            files=[]
-           
+            files = []
+
         except Exception:
             logger.exception("Failed to parse batch_predict form")
             return NumpyJSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
 
-        async def batch_predict_by_model(model_name:str , model: LudwigModel) -> dict:
+        async def batch_predict_by_model(model_name: str, model: LudwigModel) -> dict:
             try:
-                data, files = convert_batch_input(form, model.model.input_features) 
-                data_df = pd.DataFrame.from_records(data["data"], index=data.get("index"), columns=data["columns"])
+                data, files = convert_batch_input(form, model.model.input_features)
+                data_df = pd.DataFrame.from_records(
+                    data["data"], index=data.get("index"), columns=data["columns"]
+                )
                 input_features = {f[COLUMN] for f in model.config["input_features"]}
 
                 if (set(data_df.columns) & input_features) != input_features:
@@ -292,7 +309,9 @@ def server(models, allowed_origins=None):
                     },
                 }
             except Exception as exc:
-                logger.exception(f"Failed to batch predict for model '{model_name}': {exc}")
+                logger.exception(
+                    f"Failed to batch predict for model '{model_name}': {exc}"
+                )
                 return {
                     "model": model_name,
                     "response": {
@@ -307,7 +326,9 @@ def server(models, allowed_origins=None):
                 invalid_models = [name for name in model_names if name not in models]
                 if invalid_models:
                     return NumpyJSONResponse(
-                        {"error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."},
+                        {
+                            "error": f"Invalid model names: {invalid_models}. Available models: {list(models.keys())}."
+                        },
                         status_code=400,
                     )
                 target_models = {name: models[name] for name in model_names}
@@ -315,7 +336,10 @@ def server(models, allowed_origins=None):
                 target_models = models
 
             # Run batch predictions
-            tasks = [batch_predict_by_model(name, model) for name, model in target_models.items()]
+            tasks = [
+                batch_predict_by_model(name, model)
+                for name, model in target_models.items()
+            ]
             results = await asyncio.gather(*tasks)
             responses = {result["model"]: result["response"] for result in results}
             return NumpyJSONResponse(responses)
@@ -325,7 +349,9 @@ def server(models, allowed_origins=None):
         finally:
             for f in files:
                 os.remove(f.name)
+
     return app
+
 
 def _write_file(v, files):
     # Convert UploadFile to a NamedTemporaryFile to ensure it's on the disk
@@ -382,9 +408,11 @@ def convert_batch_input(form, input_features):
 
     return data, files
 
+
 async def are_models_loaded(models: Dict[str, LudwigModel]) -> bool:
     # Implement a check to verify all models are fully loaded
     return all(model is not None for model in models.values())
+
 
 def run_server(
     model_paths: dict,  # Dictionary of model IDs to paths
@@ -397,13 +425,15 @@ def run_server(
     # If model_paths is a string, convert it to a dictionary
     if isinstance(model_paths, str):
         model_paths = json.loads(model_paths)
-    
+
     models = {}
     for model_name, repo_id in model_paths.items():
         if mode == "huggingface":
             repo_id, repo_dir, save_dir = process_repo_name(repo_id, "model")
-            models[model_name] = load_model(save_dir, repo_dir, repo_id=repo_id, backend="local")
-        elif mode == "local":  
+            models[model_name] = load_model(
+                save_dir, repo_dir, repo_id=repo_id, backend="local"
+            )
+        elif mode == "local":
             models[model_name] = LudwigModel.load(repo_id, backend="local")
 
     # Check if models are loaded
@@ -422,14 +452,22 @@ def run_server(
 
 def cli(sys_argv):
     parser = argparse.ArgumentParser(
-        description="This script serves multiple pretrained models", prog="ludwig multi_serve", usage="%(prog)s [options]"
+        description="This script serves multiple pretrained models",
+        prog="ludwig multi_serve",
+        usage="%(prog)s [options]",
     )
 
     # ----------------
     # Model parameters
     # ----------------
     parser.add_argument("-m", "--model_paths", help="model to load", required=True)
-    parser.add_argument("-mode", "--mode", choices=["huggingface", "local"], help="Model loading mode: either fetch them from HuggingFace or locally ", required=True)
+    parser.add_argument(
+        "-mode",
+        "--mode",
+        choices=["huggingface", "local"],
+        help="Model loading mode: either fetch them from HuggingFace or locally ",
+        required=True,
+    )
 
     parser.add_argument(
         "-l",
@@ -450,7 +488,9 @@ def cli(sys_argv):
         type=int,
     )
 
-    parser.add_argument("-H", "--host", help="host for server (default: 0.0.0.0)", default="0.0.0.0")
+    parser.add_argument(
+        "-H", "--host", help="host for server (default: 0.0.0.0)", default="0.0.0.0"
+    )
 
     parser.add_argument(
         "-ao",

--- a/ludwig-nlu/pyproject.toml
+++ b/ludwig-nlu/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.isort]
+profile = "black"
+line_length = 120
+force_sort_within_sections = false
+order_by_type = false
+
+[tool.black]
+line-length = 120
+exclude = '''/venv|\.tox|\.egg|build'''

--- a/ludwig-nlu/requirements.txt
+++ b/ludwig-nlu/requirements.txt
@@ -70,3 +70,7 @@ datasets
 # pin required for torch 2.1.0
 urllib3<2
 ludwig==0.10.2 # Must downgrade to 0.10.2 or it won't be able to load in dockerized environment using Ludwig's official image
+black==25.1.0
+flake8==7.2.0
+isort==6.0.1
+pre-commit==4.2.0


### PR DESCRIPTION
The following PR introduces linting configurations for Python and YAML files, and integrates them with pre-commit hooks.

#### Changes:
- Added `.flake8` for Python linting with 120-character line length and specific exclusions.
- Configured `pyproject.toml` for **Black** and **Isort** formatting.
- Added `.protolint.yaml` for **Protolint** to enforce style rules on `.proto` files (e.g., naming conventions, line length).
-  Added  `Makefile` with Python-specific linting commands, such as running pre-commit hooks on all files, changed files, and specific hooks like Flake8, Black, and Isort.
- Updated Husky hooks to run linting tasks on both Python and JavaScript/TypeScript files during commits.

#### Benefits:
- Ensures consistent code style and prevents improperly formatted code from being committed.
